### PR TITLE
add stdm keyword to the metadata file

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=2.14
 description=A pro-poor land information tool that offers a complimentary land administration system that is pro-poor, gender-sensitive, affordable and sustainable for the promotion of secure land and property rights for all.
 version=1.5.2
 
-tags=land administration, tenure security, continuum of land rights, fit for purpose land administration
+tags=land administration, tenure security, continuum of land rights, fit for purpose land administration, gltn, stdm, cadastre
 
 homepage=http://www.stdm.gltn.net/
 tracker=https://github.com/gltn/stdm/issues


### PR DESCRIPTION
In the plugin manager, I was searching with `stdm` and the plugin manager couldn't find it.