### PR TITLE
Disabled "Entity Browser" > "Advance Search" action

### DIFF
--- a/ui/entity_browser.py
+++ b/ui/entity_browser.py
@@ -56,7 +56,7 @@ from stdm.ui.forms.widgets import ColumnWidgetRegistry
 from stdm.navigation import TableContentGroup
 from stdm.network.filemanager import NetworkFileManager
 from stdm.ui.forms.editor_dialog import EntityEditorDialog
-from stdm.ui.forms.advanced_search import AdvancedSearch
+# from stdm.ui.forms.advanced_search import AdvancedSearch
 from stdm.ui.sourcedocument import (
     DocumentWidget,
     network_document_path,
@@ -235,7 +235,7 @@ class EntityBrowser(SupportsManageMixin, QDialog, Ui_EntityBrowser):
         if self.can_view_supporting_documents:
             self._add_view_supporting_docs_btn()
 
-        self._add_advanced_search_btn()
+        # self._add_advanced_search_btn()
         #Connect signals
         self.buttonBox.accepted.connect(self.onAccept)
         self.tbEntity.doubleClicked[QModelIndex].connect(self.onDoubleClickView)
@@ -296,22 +296,22 @@ class EntityBrowser(SupportsManageMixin, QDialog, Ui_EntityBrowser):
         self.tbActions.addAction(self._view_docs_act)
 
 
-    def _add_advanced_search_btn(self):
-        #Add button for viewing supporting documents if supported
-        search_str = QApplication.translate(
-            'EntityBrowser',
-            'Advanced Search'
-        )
-        self._search_act = QAction(
-            QIcon(':/plugins/stdm/images/icons/advanced_search.png'),
-            search_str,
-            self
-        )
+    # def _add_advanced_search_btn(self):
+    #     #Add button for viewing supporting documents if supported
+    #     search_str = QApplication.translate(
+    #         'EntityBrowser',
+    #         'Advanced Search'
+    #     )
+    #     self._search_act = QAction(
+    #         QIcon(':/plugins/stdm/images/icons/advanced_search.png'),
+    #         search_str,
+    #         self
+    #     )
 
-        #Connect signal for showing document viewer
-        self._search_act.triggered.connect(self.on_advanced_search)
+    #     #Connect signal for showing document viewer
+    #     self._search_act.triggered.connect(self.on_advanced_search)
 
-        self.tbActions.addAction(self._search_act)
+    #     self.tbActions.addAction(self._search_act)
 
     def dateFormatter(self):
         """
@@ -537,9 +537,9 @@ class EntityBrowser(SupportsManageMixin, QDialog, Ui_EntityBrowser):
                 QItemSelectionModel.ClearAndSelect|QItemSelectionModel.Rows
             )
 
-    def on_advanced_search(self):
-        search = AdvancedSearch(self._entity, parent=self)
-        search.show()
+    # def on_advanced_search(self):
+    #     search = AdvancedSearch(self._entity, parent=self)
+    #     search.show()
 
     def on_load_document_viewer(self):
         #Slot raised to show the document viewer for the selected entity


### PR DESCRIPTION
Disabled Advanced Search action as requested by John. This solves some errors that were associated with the dialog. Nonetheless advance search functionality is important and it should be considered in future releases once it has been redesigned/debugged.