### PR TITLE
Lookup Translator Configuration KeyError fix

### DIFF
--- a/ui/importexport/lookup_dialog.py
+++ b/ui/importexport/lookup_dialog.py
@@ -121,9 +121,12 @@ class LookupDialog(QDialog, Ui_LookupTranslatorDialog, TranslatorDialogBase):
         self.cbo_default.addItem('')
 
         for lk_value in lk_values:
-            vt = unicode(lk_value)
-            text_value = lk_ent.values[vt]
-            self.cbo_default.addItem(text_value.value)
+            text_value = None
+            for k, v in lk_ent.values.items():
+                if v.value == lk_value:
+                    text_value = v.value
+            if text_value is not None:
+                self.cbo_default.addItem(text_value)
 
     def value_translator(self):
         """


### PR DESCRIPTION
This is a fix to a KeyError exception that was being raised on selecting a lookup table for translation during data import. Please test with spatial/non-spatial data import and merge.