### PR TITLE
Close/hide Import to STDM wizard on overwrite

### DIFF
--- a/ui/import_data.py
+++ b/ui/import_data.py
@@ -486,7 +486,9 @@ class ImportData(QWizard, Ui_frmImport):
                     setVectorFileDir(self.field("srcFile"))
 
                     self.InfoMessage(
-                        "All features have been imported successfully!")
+                        "All features have been imported successfully!"
+                    )
+                    success = True
 
                 else:
                     success = False
@@ -621,4 +623,3 @@ class ImportData(QWizard, Ui_frmImport):
         msg.setIcon(QMessageBox.Critical)
         msg.setText(message)
         msg.exec_()
-


### PR DESCRIPTION
This fix ensures that the Import to STDM wizard is closed on successful data import when using **_Overwrite_** option. 