### PR TITLE
Rough attempt to fix class does not have a __table__ or __tablename__ specified exception

### DIFF
--- a/stdm/data/configuration/__init__.py
+++ b/stdm/data/configuration/__init__.py
@@ -147,23 +147,14 @@ def configure_supporting_documents_inheritance(entity_supporting_docs_t,
     :return: Database model corresponding to an entity's supporting document.
     """
 
-    class ProfileSupportingDocumentProxy(base):
-        """
-        Represents the root table for storing supporting documents in a
-        given profile.
-        """
-        __table__ = profile_supporting_docs_t
-
-        __mapper_args__ = {
-            'polymorphic_identity': 'NA',
-            'polymorphic_on': 'source_entity'
-        }
-
     # Get the link columns
     t_doc_id_col = getattr(entity_supporting_docs_t.c, 'supporting_doc_id')
-    p_doc_id_col = getattr(profile_supporting_docs_t.c, 'id')
+    if profile_supporting_docs_t is not None:
+        p_doc_id_col = getattr(profile_supporting_docs_t.c, 'id')
+    else:
+        p_doc_id_col = None
 
-    class EntitySupportingDocumentProxy(ProfileSupportingDocumentProxy):
+    class EntitySupportingDocumentProxy(base):
         """
         Represents the entity supporting documents table.
         """


### PR DESCRIPTION
This is being triggered when configure_supporting_documents_inheritance
is being called with profile_supporting_docs_t having a None value

It appears as the base class isn't actually being used anywhere and
can be safely removed, as the EntitySupportingDocumentProxy subclass
overwrites the __table__ and __mapper__ values set in the base class
anyway.

The one concern is how to correctly handle p_doc_id_col when profile_supporting_docs_t
is None. Here I've also set that to None, but I suspect that will cause
issues with the

    'inherit_condition': t_doc_id_col == p_doc_id_col

part of EntitySupportingDocumentProxy.

How should we handle this situation gracefully? Is this approach acceptable?

