### PR TITLE
Make DetailsTreeView widget self contained

### DIFF
--- a/stdm/plugin.py
+++ b/stdm/plugin.py
@@ -1027,8 +1027,12 @@ class STDMQGISLoader:
                                           QApplication.translate("MobileFormGenerator", "Import Mobile Data"),
                                           self.iface.mainWindow())
 
-        dock_widget = DetailsDockWidget(self.iface, self)
-        self.details_tree_view = DetailsTreeView(self.iface, self, dock_widget)
+        self.details_dock_widget = DetailsDockWidget(self.iface)
+        self.details_dock_widget.setToggleVisibilityAction(self.feature_details_act)
+        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.details_dock_widget)
+        self.details_dock_widget.setUserVisible(False)
+
+        self.details_tree_view = DetailsTreeView(self.iface, self, self.details_dock_widget)
 
         # Add current profiles to profiles combobox
         self.load_profiles_combobox()

--- a/stdm/plugin.py
+++ b/stdm/plugin.py
@@ -1027,7 +1027,7 @@ class STDMQGISLoader:
                                           QApplication.translate("MobileFormGenerator", "Import Mobile Data"),
                                           self.iface.mainWindow())
 
-        self.details_dock_widget = DetailsDockWidget(self.iface)
+        self.details_dock_widget = DetailsDockWidget(map_canvas=self.iface.mapCanvas())
         self.details_dock_widget.setToggleVisibilityAction(self.feature_details_act)
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.details_dock_widget)
         self.details_dock_widget.setUserVisible(False)

--- a/stdm/plugin.py
+++ b/stdm/plugin.py
@@ -310,6 +310,11 @@ class STDMQGISLoader:
             self.stdmMenu.deleteLater()
             self.stdmMenu = None
 
+        if self.details_dock_widget is not None:
+            self.details_dock_widget.remove_connections()
+            self.details_dock_widget.deleteLater()
+            self.details_dock_widget = None
+
         self.remove_spatial_unit_mgr()
 
         if self.profile_status_label is not None:

--- a/stdm/plugin.py
+++ b/stdm/plugin.py
@@ -155,7 +155,7 @@ class STDMQGISLoader:
         # Initialize loader
         self.toolbarLoader = None
         self.menubarLoader = None
-        self.details_tree_view = None
+        self.details_dock_widget = None
         self.combo_action = None
         self.stdmInitToolbar = None
         self.stdmMenu = None
@@ -1027,12 +1027,11 @@ class STDMQGISLoader:
                                           QApplication.translate("MobileFormGenerator", "Import Mobile Data"),
                                           self.iface.mainWindow())
 
-        self.details_dock_widget = DetailsDockWidget(map_canvas=self.iface.mapCanvas())
+        self.details_dock_widget = DetailsDockWidget(map_canvas=self.iface.mapCanvas(), plugin=self)
         self.details_dock_widget.setToggleVisibilityAction(self.feature_details_act)
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.details_dock_widget)
         self.details_dock_widget.setUserVisible(False)
-
-        self.details_tree_view = DetailsTreeView(self.iface, self, self.details_dock_widget)
+        self.details_dock_widget.init_connections()
 
         # Add current profiles to profiles combobox
         self.load_profiles_combobox()
@@ -1048,14 +1047,9 @@ class STDMQGISLoader:
         self.docGeneratorAct.triggered.connect(self.onDocumentGenerator)
         self.spatialLayerManager.triggered.connect(self.spatialLayerMangerActivate)
 
-        self.feature_details_act.triggered.connect(self.details_tree_view.activate_feature_details)
-
         self.mobile_form_act.triggered.connect(self.mobile_form_generator)
         self.mobile_form_import.triggered.connect(self.mobile_form_importer)
 
-        self.iface.mapCanvas().currentLayerChanged.connect(
-            lambda: self.details_tree_view.activate_feature_details(False)
-        )
         contentMenu.triggered.connect(self.widgetLoader)
         self.wzdAct.triggered.connect(self.load_config_wizard)
         self.viewSTRAct.triggered.connect(self.onViewSTR)

--- a/stdm/ui/feature_details.py
+++ b/stdm/ui/feature_details.py
@@ -79,8 +79,6 @@ from stdm.utils.util import (
     entity_attr_to_model
 )
 
-DETAILS_DOCK_ON = False
-
 
 class LayerSelectionHandler(object):
     """
@@ -595,13 +593,11 @@ class DetailsDockWidget(WIDGET, BASE):
         clearing feature selection, and hiding the dock.
 
         """
-        global DETAILS_DOCK_ON
         self.iface.actionPan().trigger()
         self.plugin.feature_details_act.setChecked(False)
         self.clear_feature_selection()
         # self.clear_sel_highlight()
         self.hide()
-        DETAILS_DOCK_ON = False
 
     def closeEvent(self, event):
         """

--- a/stdm/ui/feature_details.py
+++ b/stdm/ui/feature_details.py
@@ -51,7 +51,8 @@ from qgis.core import (
 )
 from qgis.gui import (
     QgsHighlight,
-    QgsDockWidget
+    QgsDockWidget,
+    QgsMapCanvas
 )
 
 from stdm.exceptions import DummyException
@@ -527,7 +528,7 @@ class DetailsDockWidget(WIDGET, QgsDockWidget):
     The logic for the spatial entity details dock widget.
     """
 
-    def __init__(self, iface):
+    def __init__(self, map_canvas: QgsMapCanvas):
         """
         Initializes the DetailsDockWidget.
         :param iface: The QGIS interface
@@ -541,23 +542,34 @@ class DetailsDockWidget(WIDGET, QgsDockWidget):
         self.delete_btn.setIcon(GuiUtils.get_icon('remove.png'))
         self.view_document_btn.setIcon(GuiUtils.get_icon('document.png'))
 
-        self.iface = iface
+        self.map_canvas = map_canvas
 
         self.edit_btn.setDisabled(True)
         self.delete_btn.setDisabled(True)
         self.view_document_btn.setDisabled(True)
-        # LayerSelectionHandler.__init__(self, iface, plugin)
         self.setBaseSize(300, 5000)
+
+        self.visibilityChanged.connect(self._visibility_changed)
+
+    def _visibility_changed(self, visible: bool):
+        """
+        Called when dock visibility is changed
+        """
+        if not visible:
+            self.clear_feature_selection()
 
     def clear_feature_selection(self):
         """
         Clears selection of layer(s).
         """
-        map = self.iface.mapCanvas()
-        for layer in map.layers():
+
+        if not self.map_canvas:
+            return
+
+        for layer in self.map_canvas.layers():
             if layer.type() == layer.VectorLayer:
                 layer.removeSelection()
-        map.refresh()
+        self.map_canvas.refresh()
 
 
 class SelectedItem(object):

--- a/stdm/ui/feature_details.py
+++ b/stdm/ui/feature_details.py
@@ -24,7 +24,6 @@ from collections import OrderedDict
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
-    Qt,
     QDateTime,
     QDate
 )
@@ -56,7 +55,6 @@ from qgis.gui import (
     QgsMapCanvas
 )
 
-from stdm.exceptions import DummyException
 from stdm.data.configuration import (
     entity_model
 )
@@ -69,6 +67,7 @@ from stdm.data.supporting_documents import (
     supporting_doc_tables,
     document_models
 )
+from stdm.exceptions import DummyException
 from stdm.settings import current_profile
 from stdm.settings.registryconfig import (
     selection_color
@@ -81,6 +80,7 @@ from stdm.utils.util import (
     format_name,
     entity_attr_to_model
 )
+
 
 # TODO: the base class here shouldn't really be QWidget, but
 # the levels of inheritance here prohibit us to make the subclass
@@ -170,13 +170,15 @@ class LayerSelectionHandler(QWidget):
         :return: Table name.
         :rtype: str
         """
-        if layer is None: return ''
+        if layer is None:
+            return ''
 
         source = layer.source()
 
-        if source is None: return ''
+        if source is None:
+            return ''
 
-        vals = dict(re.findall('(\S+)="?(.*?)"? ', source))
+        vals = dict(re.findall(r'(\S+)="?(.*?)"? ', source))
 
         table_name = ''
         try:
@@ -337,7 +339,7 @@ class DetailsDBHandler(LayerSelectionHandler):
             widget_factory = ColumnWidgetRegistry.factory(
                 col.TYPE_INFO
             )
-            if not widget_factory is None:
+            if widget_factory is not None:
                 formatter = widget_factory(col)
                 self.column_formatter[col_name] = formatter
         self.plugin.entity_formatters[entity.name] = self.column_formatter
@@ -429,7 +431,7 @@ class DetailsDBHandler(LayerSelectionHandler):
         """
         Gets all STR records linked to a party, if the record is party record.
         :param party_id: The party id/id of the spatial unit
-        :type feature_id: Integer
+        :type party_id: Integer
         :return: The list of social tenure records
         :rtype: List
         """
@@ -535,8 +537,6 @@ class DetailsDockWidget(WIDGET, QgsDockWidget):
     def __init__(self, map_canvas: QgsMapCanvas, plugin):
         """
         Initializes the DetailsDockWidget.
-        :param iface: The QGIS interface
-        :type iface: Object
         """
         super().__init__()
 
@@ -553,9 +553,10 @@ class DetailsDockWidget(WIDGET, QgsDockWidget):
         self.view_document_btn.setDisabled(True)
         self.setBaseSize(300, 5000)
 
-        self.details_tree_view = DetailsTreeView(self, plugin, delete_button=self.delete_btn, edit_button=self.edit_btn, view_document_button=self.view_document_btn)
+        self.details_tree_view = DetailsTreeView(self, plugin, delete_button=self.delete_btn, edit_button=self.edit_btn,
+                                                 view_document_button=self.view_document_btn)
         layout = QVBoxLayout()
-        layout.setContentsMargins(0,0,0,0)
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.details_tree_view)
         self.tree_container.setLayout(layout)
 
@@ -622,7 +623,7 @@ class DetailsTreeView(DetailsDBHandler):
         self.plugin = plugin
 
         layout = QVBoxLayout()
-        layout.setContentsMargins(0,0,0,0)
+        layout.setContentsMargins(0, 0, 0, 0)
         self.view = QTreeView()
         layout.addWidget(self.view)
         self.setLayout(layout)
@@ -670,7 +671,8 @@ class DetailsTreeView(DetailsDBHandler):
             '''
         )
         self.current_profile = current_profile()
-        if self.current_profile is None: return
+        if self.current_profile is None:
+            return
 
         self.social_tenure = self.current_profile.social_tenure
         self.spatial_units = self.social_tenure.spatial_units
@@ -773,7 +775,7 @@ class DetailsTreeView(DetailsDBHandler):
 
         return config_done
 
-    def activate_feature_details(self, checked: bool=True):
+    def activate_feature_details(self, checked: bool = True):
         """
         A slot raised when the feature details button is clicked.
         :param checked: A boolean to identify if it is activated
@@ -921,7 +923,8 @@ class DetailsTreeView(DetailsDBHandler):
 
         str_records = []
 
-        if self._selected_features is None: return
+        if self._selected_features is None:
+            return
 
         self._selected_features[:] = []
         self._selected_features = self.selected_features()
@@ -941,8 +944,8 @@ class DetailsTreeView(DetailsDBHandler):
             self.disable_buttons(True)
             return
         layer_icon = GuiUtils.get_icon('layer.gif')
-        ### add non entity layer for views.
-        if not self.entity is None:
+        # add non entity layer for views.
+        if self.entity is not None:
             self.reset_tree_view(self._selected_features)
             roots = self.add_parent_tree(
                 layer_icon, format_name(self.entity.short_name)
@@ -990,7 +993,7 @@ class DetailsTreeView(DetailsDBHandler):
         """
         self.reset_tree_view()
         layer_icon = GuiUtils.get_icon('layer.gif')
-        ### add non entity layer for views.
+        # add non entity layer for views.
 
         # self.reset_tree_view(selected_features)
 
@@ -1023,7 +1026,7 @@ class DetailsTreeView(DetailsDBHandler):
         """
         self.reset_tree_view()
         table_icon = GuiUtils.get_icon('table.png')
-        ### add non entity layer for views.
+        # add non entity layer for views.
 
         str_records = []
         for spu_id in party_ids:
@@ -1120,7 +1123,7 @@ class DetailsTreeView(DetailsDBHandler):
         feature_data = []
 
         for elem in selected_features:
-            if not party_id is None:
+            if party_id is not None:
                 if elem.id() == party_id:
                     feature_map = OrderedDict(
                         list(zip(field_names, elem.attributes()))
@@ -1168,7 +1171,8 @@ class DetailsTreeView(DetailsDBHandler):
         :type str_records: List
         """
 
-        if model is None: return
+        if model is None:
+            return
 
         if isinstance(model, OrderedDict):
             # if len(model) == 0: return
@@ -1258,7 +1262,7 @@ class DetailsTreeView(DetailsDBHandler):
             party_name = party.short_name.lower().replace(' ', '_')
             party_id = '{}_id'.format(party_name)
 
-            if not party_id in record:
+            if party_id not in record:
                 return None, None
 
             if record[party_id] is not None:
@@ -1279,7 +1283,7 @@ class DetailsTreeView(DetailsDBHandler):
         for spatial_unit in spatial_units:
             spatial_unit_name = spatial_unit.name.split(self.current_profile.prefix, 1)[1]
             spatial_unit_id = '{}_id'.format(spatial_unit_name).lstrip('_')
-            if not spatial_unit_id in record:
+            if spatial_unit_id not in record:
                 return None, None
             if record[spatial_unit_id] is not None:
                 return spatial_unit, spatial_unit_id
@@ -1294,7 +1298,8 @@ class DetailsTreeView(DetailsDBHandler):
         :param feature_id: The selected feature id.
         :type feature_id: Integer
         """
-        if str_records is None: return
+        if str_records is None:
+            return
 
         if self.layer_table is None and self.plugin is not None:
             return
@@ -1705,7 +1710,8 @@ class DetailsTreeView(DetailsDBHandler):
 
         feature_edit = True
 
-        if data is None: return
+        if data is None:
+            return
 
         if isinstance(data, str):
             data_error = QApplication.translate(
@@ -1985,7 +1991,7 @@ class DetailsTreeView(DetailsDBHandler):
         else:
 
             db_model = self.feature_model(entity, id)
-        if not db_model is None:
+        if db_model is not None:
             if not hasattr(db_model, 'documents'):
                 docs = []
             else:

--- a/stdm/ui/feature_details.py
+++ b/stdm/ui/feature_details.py
@@ -562,6 +562,12 @@ class DetailsDockWidget(WIDGET, QgsDockWidget):
         """
         self.visibilityChanged.connect(self._visibility_changed)
 
+    def remove_connections(self):
+        """
+        Removes visibility based connections for the dock
+        """
+        self.visibilityChanged.disconnect(self._visibility_changed)
+
     def _visibility_changed(self, visible: bool):
         """
         Called when dock visibility is changed

--- a/stdm/ui/ui_feature_details.ui
+++ b/stdm/ui/ui_feature_details.ui
@@ -1,147 +1,130 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>DetailsDock</class>
-    <widget class="QDockWidget" name="DetailsDock">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>400</width>
-                <height>300</height>
-            </rect>
+ <class>DetailsDock</class>
+ <widget class="QDockWidget" name="DetailsDock">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="allowedAreas">
+   <set>Qt::AllDockWidgetAreas</set>
+  </property>
+  <property name="windowTitle">
+   <string>Feature Details</string>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QToolButton" name="edit_btn">
+        <property name="minimumSize">
+         <size>
+          <width>23</width>
+          <height>22</height>
+         </size>
         </property>
-        <property name="allowedAreas">
-            <set>Qt::AllDockWidgetAreas</set>
+        <property name="toolTip">
+         <string>Edit attribute details</string>
         </property>
-        <property name="windowTitle">
-            <string>Feature Details</string>
+        <property name="text">
+         <string>...</string>
         </property>
-        <widget class="QWidget" name="dockWidgetContents">
-            <layout class="QVBoxLayout" name="verticalLayout">
-                <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout">
-                        <item>
-                            <widget class="QToolButton" name="edit_btn">
-                                <property name="minimumSize">
-                                    <size>
-                                        <width>23</width>
-                                        <height>22</height>
-                                    </size>
-                                </property>
-                                <property name="toolTip">
-                                    <string>Edit attribute details</string>
-                                </property>
-                                <property name="text">
-                                    <string>...</string>
-                                </property>
-                                <property name="iconSize">
-                                    <size>
-                                        <width>16</width>
-                                        <height>16</height>
-                                    </size>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <widget class="QToolButton" name="delete_btn">
-                                <property name="minimumSize">
-                                    <size>
-                                        <width>23</width>
-                                        <height>22</height>
-                                    </size>
-                                </property>
-                                <property name="toolTip">
-                                    <string>Delete a record</string>
-                                </property>
-                                <property name="text">
-                                    <string>...</string>
-                                </property>
-                                <property name="iconSize">
-                                    <size>
-                                        <width>16</width>
-                                        <height>16</height>
-                                    </size>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <widget class="QToolButton" name="view_document_btn">
-                                <property name="minimumSize">
-                                    <size>
-                                        <width>23</width>
-                                        <height>22</height>
-                                    </size>
-                                </property>
-                                <property name="maximumSize">
-                                    <size>
-                                        <width>16777215</width>
-                                        <height>16777215</height>
-                                    </size>
-                                </property>
-                                <property name="toolTip">
-                                    <string>View record supporting documents</string>
-                                </property>
-                                <property name="text">
-                                    <string>...</string>
-                                </property>
-                                <property name="iconSize">
-                                    <size>
-                                        <width>16</width>
-                                        <height>16</height>
-                                    </size>
-                                </property>
-                            </widget>
-                        </item>
-                        <item>
-                            <spacer name="horizontalSpacer">
-                                <property name="orientation">
-                                    <enum>Qt::Horizontal</enum>
-                                </property>
-                                <property name="sizeHint" stdset="0">
-                                    <size>
-                                        <width>40</width>
-                                        <height>20</height>
-                                    </size>
-                                </property>
-                            </spacer>
-                        </item>
-                    </layout>
-                </item>
-                <item>
-                    <widget class="QScrollArea" name="tree_scrollArea">
-                        <property name="minimumSize">
-                            <size>
-                                <width>70</width>
-                                <height>70</height>
-                            </size>
-                        </property>
-                        <property name="frameShape">
-                            <enum>QFrame::NoFrame</enum>
-                        </property>
-                        <property name="frameShadow">
-                            <enum>QFrame::Plain</enum>
-                        </property>
-                        <property name="lineWidth">
-                            <number>0</number>
-                        </property>
-                        <property name="widgetResizable">
-                            <bool>true</bool>
-                        </property>
-                        <widget class="QWidget" name="scrollAreaWidgetContents">
-                            <property name="geometry">
-                                <rect>
-                                    <x>0</x>
-                                    <y>0</y>
-                                    <width>378</width>
-                                    <height>221</height>
-                                </rect>
-                            </property>
-                            <layout class="QVBoxLayout" name="verticalLayout_2"/>
-                        </widget>
-                    </widget>
-                </item>
-            </layout>
-        </widget>
-    </widget>
-    <connections/>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="delete_btn">
+        <property name="minimumSize">
+         <size>
+          <width>23</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Delete a record</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="view_document_btn">
+        <property name="minimumSize">
+         <size>
+          <width>23</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>View record supporting documents</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QWidget" name="tree_container" native="true"/>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/stdm/ui/ui_view_str.ui
+++ b/stdm/ui/ui_view_str.ui
@@ -1,310 +1,309 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>frmManageSTR</class>
-    <widget class="QMainWindow" name="frmManageSTR">
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>968</width>
-                <height>638</height>
-            </rect>
+ <class>frmManageSTR</class>
+ <widget class="QMainWindow" name="frmManageSTR">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>968</width>
+    <height>638</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>View Social Tenure Relationship</string>
+  </property>
+  <property name="documentMode">
+   <bool>false</bool>
+  </property>
+  <property name="dockOptions">
+   <set>QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="1" column="0">
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <widget class="QFrame" name="frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>380</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>450</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <property name="leftMargin">
+         <number>1</number>
         </property>
-        <property name="windowTitle">
-            <string>View Social Tenure Relationship</string>
+        <property name="topMargin">
+         <number>1</number>
         </property>
-        <property name="documentMode">
-            <bool>false</bool>
+        <property name="rightMargin">
+         <number>1</number>
         </property>
-        <property name="dockOptions">
-            <set>QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
+        <property name="bottomMargin">
+         <number>1</number>
         </property>
-        <widget class="QWidget" name="centralwidget">
-            <layout class="QGridLayout" name="gridLayout">
-                <item row="1" column="0">
-                    <widget class="QSplitter" name="splitter">
-                        <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
-                        </property>
-                        <widget class="QFrame" name="frame">
-                            <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                </sizepolicy>
-                            </property>
-                            <property name="minimumSize">
-                                <size>
-                                    <width>380</width>
-                                    <height>0</height>
-                                </size>
-                            </property>
-                            <property name="maximumSize">
-                                <size>
-                                    <width>450</width>
-                                    <height>16777215</height>
-                                </size>
-                            </property>
-                            <property name="frameShape">
-                                <enum>QFrame::NoFrame</enum>
-                            </property>
-                            <property name="frameShadow">
-                                <enum>QFrame::Raised</enum>
-                            </property>
-                            <layout class="QGridLayout" name="gridLayout_5">
-                                <property name="margin">
-                                    <number>1</number>
-                                </property>
-                                <item row="0" column="0">
-                                    <widget class="QGroupBox" name="groupBox">
-                                        <property name="minimumSize">
-                                            <size>
-                                                <width>0</width>
-                                                <height>250</height>
-                                            </size>
-                                        </property>
-                                        <property name="maximumSize">
-                                            <size>
-                                                <width>16777215</width>
-                                                <height>250</height>
-                                            </size>
-                                        </property>
-                                        <property name="title">
-                                            <string>Search by:</string>
-                                        </property>
-                                        <layout class="QGridLayout" name="gridLayout_4">
-                                            <item row="0" column="0" colspan="2">
-                                                <widget class="QTabWidget" name="tbSTREntity"/>
-                                            </item>
-                                            <item row="1" column="0">
-                                                <widget class="QPushButton" name="btnSearch">
-                                                    <property name="minimumSize">
-                                                        <size>
-                                                            <width>0</width>
-                                                            <height>30</height>
-                                                        </size>
-                                                    </property>
-                                                    <property name="text">
-                                                        <string>Search</string>
-                                                    </property>
-                                                </widget>
-                                            </item>
-                                            <item row="1" column="1">
-                                                <widget class="QPushButton" name="btnClearSearch">
-                                                    <property name="minimumSize">
-                                                        <size>
-                                                            <width>0</width>
-                                                            <height>30</height>
-                                                        </size>
-                                                    </property>
-                                                    <property name="text">
-                                                        <string>Clear Results</string>
-                                                    </property>
-                                                </widget>
-                                            </item>
-                                        </layout>
-                                    </widget>
-                                </item>
-                                <item row="1" column="0">
-                                    <widget class="QGroupBox" name="groupBox_2">
-                                        <property name="title">
-                                            <string>Search Results:</string>
-                                        </property>
-                                        <layout class="QVBoxLayout" name="verticalLayout">
-                                            <property name="topMargin">
-                                                <number>5</number>
-                                            </property>
-                                            <item>
-                                                <layout class="QVBoxLayout" name="toolbarVBox">
-                                                    <property name="spacing">
-                                                        <number>0</number>
-                                                    </property>
-                                                </layout>
-                                            </item>
-                                            <item>
-                                                <widget class="QScrollArea" name="tree_scrollArea">
-                                                    <property name="frameShape">
-                                                        <enum>QFrame::NoFrame</enum>
-                                                    </property>
-                                                    <property name="frameShadow">
-                                                        <enum>QFrame::Plain</enum>
-                                                    </property>
-                                                    <property name="widgetResizable">
-                                                        <bool>true</bool>
-                                                    </property>
-                                                    <widget class="QWidget" name="scrollAreaWidgetContents">
-                                                        <property name="geometry">
-                                                            <rect>
-                                                                <x>0</x>
-                                                                <y>0</y>
-                                                                <width>424</width>
-                                                                <height>85</height>
-                                                            </rect>
-                                                        </property>
-                                                    </widget>
-                                                </widget>
-                                            </item>
-                                        </layout>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                        <widget class="QFrame" name="frame_2">
-                            <property name="enabled">
-                                <bool>true</bool>
-                            </property>
-                            <property name="frameShape">
-                                <enum>QFrame::Panel</enum>
-                            </property>
-                            <property name="frameShadow">
-                                <enum>QFrame::Raised</enum>
-                            </property>
-                            <layout class="QGridLayout" name="gridLayout_3">
-                                <property name="margin">
-                                    <number>1</number>
-                                </property>
-                                <property name="spacing">
-                                    <number>7</number>
-                                </property>
-                                <item row="0" column="0">
-                                    <widget class="QToolBox" name="toolBox">
-                                        <property name="font">
-                                            <font>
-                                                <weight>50</weight>
-                                                <bold>false</bold>
-                                                <strikeout>false</strikeout>
-                                            </font>
-                                        </property>
-                                        <property name="cursor">
-                                            <cursorShape>PointingHandCursor</cursorShape>
-                                        </property>
-                                        <property name="inputMethodHints">
-                                            <set>Qt::ImhNone</set>
-                                        </property>
-                                        <property name="frameShape">
-                                            <enum>QFrame::NoFrame</enum>
-                                        </property>
-                                        <property name="frameShadow">
-                                            <enum>QFrame::Sunken</enum>
-                                        </property>
-                                        <property name="lineWidth">
-                                            <number>1</number>
-                                        </property>
-                                        <property name="midLineWidth">
-                                            <number>1</number>
-                                        </property>
-                                        <property name="currentIndex">
-                                            <number>0</number>
-                                        </property>
-                                        <property name="tabSpacing">
-                                            <number>1</number>
-                                        </property>
-                                        <widget class="QWidget" name="page_1">
-                                            <property name="geometry">
-                                                <rect>
-                                                    <x>0</x>
-                                                    <y>0</y>
-                                                    <width>486</width>
-                                                    <height>333</height>
-                                                </rect>
-                                            </property>
-                                            <attribute name="label">
-                                                <string>Spatial Unit Preview</string>
-                                            </attribute>
-                                            <layout class="QVBoxLayout" name="verticalLayout_2">
-                                                <item>
-                                                    <widget class="SpatialPreview" name="tbPropertyPreview"/>
-                                                </item>
-                                            </layout>
-                                        </widget>
-                                        <widget class="QWidget" name="page_2">
-                                            <property name="geometry">
-                                                <rect>
-                                                    <x>0</x>
-                                                    <y>0</y>
-                                                    <width>486</width>
-                                                    <height>326</height>
-                                                </rect>
-                                            </property>
-                                            <attribute name="label">
-                                                <string>Supporting Documents</string>
-                                            </attribute>
-                                            <layout class="QVBoxLayout" name="verticalLayout_3">
-                                                <item>
-                                                    <widget class="QTabWidget" name="tbSupportingDocs">
-                                                        <property name="maximumSize">
-                                                            <size>
-                                                                <width>16777215</width>
-                                                                <height>16777215</height>
-                                                            </size>
-                                                        </property>
-                                                    </widget>
-                                                </item>
-                                            </layout>
-                                        </widget>
-                                    </widget>
-                                </item>
-                            </layout>
-                        </widget>
-                    </widget>
-                </item>
-                <item row="2" column="0">
-                    <widget class="QDialogButtonBox" name="buttonBox">
-                        <property name="standardButtons">
-                            <set>QDialogButtonBox::Close</set>
-                        </property>
-                    </widget>
-                </item>
-                <item row="0" column="0">
-                    <layout class="QVBoxLayout" name="vl_notification"/>
-                </item>
+        <item row="0" column="0">
+         <widget class="QGroupBox" name="groupBox">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>250</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>250</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Search by:</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_4">
+           <item row="0" column="0" colspan="2">
+            <widget class="QTabWidget" name="tbSTREntity"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QPushButton" name="btnSearch">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>30</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Search</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QPushButton" name="btnClearSearch">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>30</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Clear Results</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="title">
+           <string>Search Results:</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+           <property name="topMargin">
+            <number>5</number>
+           </property>
+           <item>
+            <layout class="QVBoxLayout" name="toolbarVBox">
+             <property name="spacing">
+              <number>0</number>
+             </property>
             </layout>
-        </widget>
-        <widget class="QToolBar" name="tb_actions">
-            <property name="windowTitle">
-                <string>toolBar</string>
-            </property>
-            <property name="movable">
-                <bool>false</bool>
-            </property>
-            <property name="toolButtonStyle">
-                <enum>Qt::ToolButtonTextBesideIcon</enum>
-            </property>
-            <property name="floatable">
-                <bool>false</bool>
-            </property>
-            <attribute name="toolBarArea">
-                <enum>TopToolBarArea</enum>
-            </attribute>
-            <attribute name="toolBarBreak">
-                <bool>false</bool>
-            </attribute>
-        </widget>
-    </widget>
-    <customwidgets>
-        <customwidget>
-            <class>SpatialPreview</class>
-            <extends>QTabWidget</extends>
-            <header>stdm.ui.property_preview</header>
-            <container>1</container>
-        </customwidget>
-    </customwidgets>
-    <connections>
-        <connection>
-            <sender>buttonBox</sender>
-            <signal>rejected()</signal>
-            <receiver>frmManageSTR</receiver>
-            <slot>close()</slot>
-            <hints>
-                <hint type="sourcelabel">
-                    <x>461</x>
-                    <y>586</y>
-                </hint>
-                <hint type="destinationlabel">
-                    <x>461</x>
-                    <y>303</y>
-                </hint>
-            </hints>
-        </connection>
-    </connections>
+           </item>
+           <item>
+            <widget class="QWidget" name="str_tree_container" native="true"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QFrame" name="frame_2">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Panel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <property name="leftMargin">
+         <number>1</number>
+        </property>
+        <property name="topMargin">
+         <number>1</number>
+        </property>
+        <property name="rightMargin">
+         <number>1</number>
+        </property>
+        <property name="bottomMargin">
+         <number>1</number>
+        </property>
+        <property name="spacing">
+         <number>7</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QToolBox" name="toolBox">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+            <strikeout>false</strikeout>
+           </font>
+          </property>
+          <property name="cursor">
+           <cursorShape>PointingHandCursor</cursorShape>
+          </property>
+          <property name="inputMethodHints">
+           <set>Qt::ImhNone</set>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Sunken</enum>
+          </property>
+          <property name="lineWidth">
+           <number>1</number>
+          </property>
+          <property name="midLineWidth">
+           <number>1</number>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="tabSpacing">
+           <number>1</number>
+          </property>
+          <widget class="QWidget" name="page_1">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>492</width>
+             <height>316</height>
+            </rect>
+           </property>
+           <attribute name="label">
+            <string>Spatial Unit Preview</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="SpatialPreview" name="tbPropertyPreview"/>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="page_2">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>492</width>
+             <height>316</height>
+            </rect>
+           </property>
+           <attribute name="label">
+            <string>Supporting Documents</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <item>
+             <widget class="QTabWidget" name="tbSupportingDocs">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Close</set>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <layout class="QVBoxLayout" name="vl_notification"/>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QToolBar" name="tb_actions">
+   <property name="windowTitle">
+    <string>toolBar</string>
+   </property>
+   <property name="movable">
+    <bool>false</bool>
+   </property>
+   <property name="toolButtonStyle">
+    <enum>Qt::ToolButtonTextBesideIcon</enum>
+   </property>
+   <property name="floatable">
+    <bool>false</bool>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SpatialPreview</class>
+   <extends>QTabWidget</extends>
+   <header>stdm.ui.property_preview</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>frmManageSTR</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>461</x>
+     <y>586</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>461</x>
+     <y>303</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/stdm/ui/view_str.py
+++ b/stdm/ui/view_str.py
@@ -168,9 +168,19 @@ class ViewSTRWidget(WIDGET, BASE):
 
         self._source_doc_manager.setEditPermissions(False)
 
+        self.addSTR = None
+        self.editSTR = None
+        self.deleteSTR = None
+
         self.initGui()
         self.add_spatial_unit_layer()
-        self.details_tree_view = DetailsTreeView(self._plugin, self)
+
+        self.details_tree_view = DetailsTreeView(parent=self, plugin=self._plugin)
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0,0,0,0)
+        layout.addWidget(self.details_tree_view)
+        self.str_tree_container.setLayout(layout)
+
         # else:
         #     self.details_tree_view = self._plugin.details_tree_view
         self.details_tree_view.activate_feature_details(True)

--- a/stdm/ui/view_str.py
+++ b/stdm/ui/view_str.py
@@ -61,8 +61,6 @@ from sqlalchemy import (
     String
 )
 
-import stdm.data
-from stdm.exceptions import DummyException
 from stdm.data import globals
 from stdm.data.configuration import entity_model
 from stdm.data.database import Content
@@ -70,6 +68,7 @@ from stdm.data.pg_utils import pg_table_count
 from stdm.data.qtmodels import (
     BaseSTDMTableModel
 )
+from stdm.exceptions import DummyException
 from stdm.security.authorization import Authorizer
 from stdm.settings import current_profile
 from stdm.ui.feature_details import DetailsTreeView, SelectedItem
@@ -177,7 +176,7 @@ class ViewSTRWidget(WIDGET, BASE):
 
         self.details_tree_view = DetailsTreeView(parent=self, plugin=self._plugin)
         layout = QVBoxLayout()
-        layout.setContentsMargins(0,0,0,0)
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.details_tree_view)
         self.str_tree_container.setLayout(layout)
 
@@ -352,7 +351,7 @@ class ViewSTRWidget(WIDGET, BASE):
                     str(t.name), t.short_name
                 )
 
-                if not entity_cfg is None:
+                if entity_cfg is not None:
                     entity_widget = self.add_entity_config(entity_cfg)
 
                     # entity_widget.setNodeFormatter(
@@ -549,7 +548,6 @@ class ViewSTRWidget(WIDGET, BASE):
                 self.toolBox.setCurrentIndex(1)
             self.disable_buttons(False)
 
-
         # party node - edit party
         elif item.data() in self.details_tree_view.spatial_unit_items.keys():
             self.toolBox.setCurrentIndex(0)
@@ -587,7 +585,7 @@ class ViewSTRWidget(WIDGET, BASE):
             party_id = '{}_id'.format(party_name)
             if party_id not in record.__dict__:
                 return None
-            if record.__dict__[party_id] != None:
+            if record.__dict__[party_id] is not None:
                 party_id_obj = getattr(self.str_model, party_id)
                 return party_id_obj
 
@@ -839,6 +837,7 @@ class EntitySearchItem(QObject):
     """
 
     def __init__(self, formatter=None):
+        super().__init__()
         # Specify the formatter that should be
         # applied on the result item. It should
         # inherit from 'stdm.navigation.STRNodeFormatter'
@@ -1053,8 +1052,8 @@ class STRViewEntityWidget(WIDGET2, BASE2, EntitySearchItem):
 
         prog_dialog.setValue(2)
         # Try to get the corresponding search term value from the completer model
-        if not self._completer_model is None:
-            reg_exp = QRegExp("^%s$" % (search_term), Qt.CaseInsensitive,
+        if self._completer_model is not None:
+            reg_exp = QRegExp("^%s$" % search_term, Qt.CaseInsensitive,
                               QRegExp.RegExp2)
             self._proxy_completer_model.setFilterRegExp(reg_exp)
 
@@ -1110,7 +1109,7 @@ class STRViewEntityWidget(WIDGET2, BASE2, EntitySearchItem):
                             func.lower(value_obj).like(search_term + '%')
                         ).first()
 
-                    if not result is None:
+                    if result is not None:
                         results = modelQueryObj.filter(
                             queryObjProperty == result.id
                         ).all()

--- a/stdm/ui/view_str.py
+++ b/stdm/ui/view_str.py
@@ -170,7 +170,7 @@ class ViewSTRWidget(WIDGET, BASE):
 
         self.initGui()
         self.add_spatial_unit_layer()
-        self.details_tree_view = DetailsTreeView(iface, self._plugin, self)
+        self.details_tree_view = DetailsTreeView(self._plugin, self)
         # else:
         #     self.details_tree_view = self._plugin.details_tree_view
         self.details_tree_view.activate_feature_details(True)

--- a/stdm/ui/view_str.py
+++ b/stdm/ui/view_str.py
@@ -174,7 +174,6 @@ class ViewSTRWidget(WIDGET, BASE):
         # else:
         #     self.details_tree_view = self._plugin.details_tree_view
         self.details_tree_view.activate_feature_details(True)
-        self.details_tree_view.add_tree_view()
         self.details_tree_view.model.clear()
 
         count = pg_table_count(self.curr_profile.social_tenure.name)


### PR DESCRIPTION
In preparation for the new STR preview widget, we need to make DetailsTreeView a nice self-contained, reusable widget